### PR TITLE
Set tail to next-value

### DIFF
--- a/src/com/manigfeald/queue.clj
+++ b/src/com/manigfeald/queue.clj
@@ -30,7 +30,7 @@
               (.compareAndSet tail tail-value node)
               (recur))
             (do
-              (.compareAndSet tail tail-value node)
+              (.compareAndSet tail tail-value nxt-value)
               (recur)))
           (recur))))))
 


### PR DESCRIPTION
I'm only testing with the following:
```clojure
(comment

  (let [q         (java.util.concurrent.LinkedBlockingQueue.)
        size      45
        done      (java.util.concurrent.CountDownLatch. 45)
        additions 1e5]
    (time (do (doseq [n (range size)]
                (.start (Thread. (fn []
                                   (doseq [i (range additions)]
                                     (.add q i))
                                   (.countDown done)))))
              (.await done))))

  (let [q         (queue)
        size      45
        done      (java.util.concurrent.CountDownLatch. 45)
        additions 1e5]
    (time (do (doseq [n (range size)]
                (.start (Thread. (fn []
                                   (doseq [i (range additions)]
                                     (enqueue q i))
                                   (.countDown done)))))
              (.await done))))

  )
```

but it seems this patch clears up the deadlock